### PR TITLE
Add Git repository action buttons to main window

### DIFF
--- a/DiffusionNexus.Installers/DiffusionNexus.Installers/ViewModels/MainWindowViewModel.cs
+++ b/DiffusionNexus.Installers/DiffusionNexus.Installers/ViewModels/MainWindowViewModel.cs
@@ -468,6 +468,37 @@ namespace DiffusionNexus.Installers.ViewModels
         }
 
         [RelayCommand]
+        private void EditRepository(GitRepositoryItemViewModel? repository)
+        {
+            if (repository is null)
+            {
+                return;
+            }
+
+            SelectedRepository = repository;
+        }
+
+        [RelayCommand]
+        private void DeleteRepository(GitRepositoryItemViewModel? repository)
+        {
+            if (repository is null)
+            {
+                return;
+            }
+
+            _configuration.GitRepositories.Remove(repository.Model);
+            GitRepositories.Remove(repository);
+
+            if (SelectedRepository == repository)
+            {
+                SelectedRepository = null;
+            }
+
+            UpdateRepositoryPriorities();
+            MarkDirty();
+        }
+
+        [RelayCommand]
         private void AddModel()
         {
             var model = new ModelDownload

--- a/DiffusionNexus.Installers/DiffusionNexus.Installers/Views/MainWindow.axaml
+++ b/DiffusionNexus.Installers/DiffusionNexus.Installers/Views/MainWindow.axaml
@@ -125,6 +125,20 @@
                                     <DataGridTextColumn Header="Url" Binding="{Binding Url, Mode=TwoWay}" Width="*" />
                                     <DataGridCheckBoxColumn Header="Install Requirements"
                                                             Binding="{Binding InstallRequirements, Mode=TwoWay}" />
+                                    <DataGridTemplateColumn Header="Actions" Width="140">
+                                        <DataGridTemplateColumn.CellTemplate>
+                                            <DataTemplate>
+                                                <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Center">
+                                                    <Button Content="Edit"
+                                                            Command="{Binding $parent[DataGrid].DataContext.EditRepositoryCommand}"
+                                                            CommandParameter="{Binding .}" />
+                                                    <Button Content="Delete"
+                                                            Command="{Binding $parent[DataGrid].DataContext.DeleteRepositoryCommand}"
+                                                            CommandParameter="{Binding .}" />
+                                                </StackPanel>
+                                            </DataTemplate>
+                                        </DataGridTemplateColumn.CellTemplate>
+                                    </DataGridTemplateColumn>
                                 </DataGrid.Columns>
                             </DataGrid>
                             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">


### PR DESCRIPTION
## Summary
- add commands to edit or delete individual Git repository rows
- expose edit and delete buttons in the Git repository grid alongside existing CRUD controls

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68e4ca2bd5888332bb00a11bf9650247