### PR TITLE
Ensure Git repository dialog commits changes

### DIFF
--- a/DiffusionNexus.Installers/DiffusionNexus.Installers/ViewModels/GitRepositoryEditorViewModel.cs
+++ b/DiffusionNexus.Installers/DiffusionNexus.Installers/ViewModels/GitRepositoryEditorViewModel.cs
@@ -1,0 +1,90 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using DiffusionNexus.Core.Models;
+
+namespace DiffusionNexus.Installers.ViewModels
+{
+    public sealed partial class GitRepositoryEditorViewModel : ObservableObject
+    {
+        [ObservableProperty]
+        private string _title = string.Empty;
+
+        [ObservableProperty]
+        private string _name = string.Empty;
+
+        [ObservableProperty]
+        private string _url = string.Empty;
+
+        [ObservableProperty]
+        private bool _installRequirements = true;
+
+        [ObservableProperty]
+        private int _priority;
+
+        [ObservableProperty]
+        private bool _canSave;
+
+        public static GitRepositoryEditorViewModel ForNew(int nextPriority)
+        {
+            return new GitRepositoryEditorViewModel
+            {
+                Title = "Add Git Repository",
+                InstallRequirements = true,
+                Priority = nextPriority,
+                CanSave = false
+            };
+        }
+
+        public static GitRepositoryEditorViewModel FromExisting(GitRepositoryItemViewModel repository)
+        {
+            return new GitRepositoryEditorViewModel
+            {
+                Title = "Edit Git Repository",
+                Name = repository.Name,
+                Url = repository.Url,
+                InstallRequirements = repository.InstallRequirements,
+                Priority = repository.Priority,
+                CanSave = !string.IsNullOrWhiteSpace(repository.Name) && !string.IsNullOrWhiteSpace(repository.Url)
+            };
+        }
+
+        public GitRepository ToModel()
+        {
+            return new GitRepository
+            {
+                Name = Name.Trim(),
+                Url = Url.Trim(),
+                InstallRequirements = InstallRequirements,
+                Priority = Priority
+            };
+        }
+
+        public void ApplyTo(GitRepositoryItemViewModel repository)
+        {
+            repository.Name = Name.Trim();
+            repository.Url = Url.Trim();
+            repository.InstallRequirements = InstallRequirements;
+        }
+
+        public void ApplyTo(GitRepository repository)
+        {
+            repository.Name = Name.Trim();
+            repository.Url = Url.Trim();
+            repository.InstallRequirements = InstallRequirements;
+        }
+
+        partial void OnNameChanged(string value)
+        {
+            UpdateCanSave();
+        }
+
+        partial void OnUrlChanged(string value)
+        {
+            UpdateCanSave();
+        }
+
+        private void UpdateCanSave()
+        {
+            CanSave = !string.IsNullOrWhiteSpace(Name) && !string.IsNullOrWhiteSpace(Url);
+        }
+    }
+}

--- a/DiffusionNexus.Installers/DiffusionNexus.Installers/Views/GitRepositoryEditorWindow.axaml
+++ b/DiffusionNexus.Installers/DiffusionNexus.Installers/Views/GitRepositoryEditorWindow.axaml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:vm="clr-namespace:DiffusionNexus.Installers.ViewModels"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        x:Class="DiffusionNexus.Installers.Views.GitRepositoryEditorWindow"
+        Width="480"
+        Height="260"
+        CanResize="False"
+        WindowStartupLocation="CenterOwner"
+        x:CompileBindings="False"
+        mc:Ignorable="d"
+        d:DataContext="{d:DesignInstance Type=vm:GitRepositoryEditorViewModel}">
+    <Grid RowDefinitions="Auto,*,Auto" RowSpacing="12" Margin="20">
+        <TextBlock Text="{Binding Title}" FontSize="18" FontWeight="SemiBold" />
+
+        <StackPanel Grid.Row="1" Spacing="12">
+            <StackPanel Orientation="Horizontal" Spacing="8">
+                <TextBlock Text="Priority" Width="120" VerticalAlignment="Center" />
+                <TextBlock Text="{Binding Priority}" VerticalAlignment="Center" />
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Spacing="8">
+                <TextBlock Text="Name" Width="120" VerticalAlignment="Center" />
+                <TextBox Width="260"
+                         Text="{Binding Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+            </StackPanel>
+            <StackPanel Orientation="Horizontal" Spacing="8">
+                <TextBlock Text="Repository URL" Width="120" VerticalAlignment="Center" />
+                <TextBox Width="260"
+                         TextWrapping="Wrap"
+                         Text="{Binding Url, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+            </StackPanel>
+            <CheckBox Content="Install requirements"
+                      IsChecked="{Binding InstallRequirements, Mode=TwoWay}" />
+        </StackPanel>
+
+        <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="12">
+            <Button Width="100" Content="Cancel" Click="OnCancelClick" />
+            <Button Width="120"
+                    Content="Save"
+                    IsDefault="True"
+                    IsEnabled="{Binding CanSave}"
+                    Click="OnSaveClick" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/DiffusionNexus.Installers/DiffusionNexus.Installers/Views/GitRepositoryEditorWindow.axaml.cs
+++ b/DiffusionNexus.Installers/DiffusionNexus.Installers/Views/GitRepositoryEditorWindow.axaml.cs
@@ -1,0 +1,23 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+
+namespace DiffusionNexus.Installers.Views
+{
+    public partial class GitRepositoryEditorWindow : Window
+    {
+        public GitRepositoryEditorWindow()
+        {
+            InitializeComponent();
+        }
+
+        private void OnSaveClick(object? sender, RoutedEventArgs e)
+        {
+            Close(true);
+        }
+
+        private void OnCancelClick(object? sender, RoutedEventArgs e)
+        {
+            Close(false);
+        }
+    }
+}

--- a/DiffusionNexus.Installers/DiffusionNexus.Installers/Views/MainWindow.axaml
+++ b/DiffusionNexus.Installers/DiffusionNexus.Installers/Views/MainWindow.axaml
@@ -114,7 +114,8 @@
                             <TextBlock Text="Git Repositories"
                                        FontSize="16"
                                        FontWeight="SemiBold" />
-                            <DataGrid ItemsSource="{Binding GitRepositories}"
+                            <DataGrid x:Name="GitRepositoriesGrid"
+                                      ItemsSource="{Binding GitRepositories}"
                                       SelectedItem="{Binding SelectedRepository, Mode=TwoWay}"
                                       AutoGenerateColumns="False"
                                       HeadersVisibility="Column"
@@ -125,6 +126,20 @@
                                     <DataGridTextColumn Header="Url" Binding="{Binding Url, Mode=TwoWay}" Width="*" />
                                     <DataGridCheckBoxColumn Header="Install Requirements"
                                                             Binding="{Binding InstallRequirements, Mode=TwoWay}" />
+                                    <DataGridTemplateColumn Header="Actions" Width="140">
+                                        <DataGridTemplateColumn.CellTemplate>
+                                            <DataTemplate>
+                                                <StackPanel Orientation="Horizontal" Spacing="8">
+                                                    <Button Content="Edit"
+                                                            Command="{Binding $parent[DataGrid].DataContext.EditRepositoryCommand}"
+                                                            CommandParameter="{Binding}" />
+                                                    <Button Content="Delete"
+                                                            Command="{Binding $parent[DataGrid].DataContext.DeleteRepositoryCommand}"
+                                                            CommandParameter="{Binding}" />
+                                                </StackPanel>
+                                            </DataTemplate>
+                                        </DataGridTemplateColumn.CellTemplate>
+                                    </DataGridTemplateColumn>
                                 </DataGrid.Columns>
                             </DataGrid>
                             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">

--- a/DiffusionNexus.Installers/DiffusionNexus.Installers/Views/MainWindow.axaml.cs
+++ b/DiffusionNexus.Installers/DiffusionNexus.Installers/Views/MainWindow.axaml.cs
@@ -10,18 +10,58 @@ namespace DiffusionNexus.Installers.Views
 {
     public partial class MainWindow : Window
     {
+        private readonly DataGrid? _gitRepositoriesGrid;
+        private MainWindowViewModel? _attachedViewModel;
+
         public MainWindow()
         {
             InitializeComponent();
+            _gitRepositoriesGrid = this.FindControl<DataGrid>("GitRepositoriesGrid");
             DataContextChanged += OnDataContextChanged;
         }
 
         private void OnDataContextChanged(object? sender, EventArgs e)
         {
+            if (_attachedViewModel is not null)
+            {
+                _attachedViewModel.EditRepositoryRequested -= OnEditRepositoryRequested;
+                _attachedViewModel.RepositoryEditorAsync = null;
+            }
+
             if (DataContext is MainWindowViewModel vm)
             {
                 vm.AttachStorageInteraction(new AvaloniaStorageInteractionService(this));
+                vm.EditRepositoryRequested += OnEditRepositoryRequested;
+                vm.RepositoryEditorAsync = ShowRepositoryEditorAsync;
+                _attachedViewModel = vm;
             }
+            else
+            {
+                _attachedViewModel = null;
+            }
+        }
+
+        private void OnEditRepositoryRequested(object? sender, GitRepositoryItemViewModel repository)
+        {
+            if (_gitRepositoriesGrid is null)
+            {
+                return;
+            }
+
+            _gitRepositoriesGrid.SelectedItem = repository;
+            _gitRepositoriesGrid.Focus();
+        }
+
+        private async Task<bool> ShowRepositoryEditorAsync(GitRepositoryEditorViewModel editor, bool _)
+        {
+            var dialog = new GitRepositoryEditorWindow
+            {
+                Title = editor.Title,
+                DataContext = editor
+            };
+
+            var result = await dialog.ShowDialog<bool?>(this);
+            return result is true;
         }
 
         private sealed class AvaloniaStorageInteractionService : IStorageInteractionService


### PR DESCRIPTION
## Summary
- rework the add/edit commands to build repositories from the dialog view model only after acceptance so new entries appear immediately
- extend the repository editor view model with helpers that can materialize GitRepository models or update existing rows
- simplify the main window dialog host to just present the supplied editor view model and return whether it was accepted

## Testing
- dotnet build DiffusionNexus.Installers/DiffusionNexus.Installers.sln

------
https://chatgpt.com/codex/tasks/task_e_68e4ca2bd5888332bb00a11bf9650247